### PR TITLE
ci/cd: add vaccelrt-agent in release binaries

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -199,6 +199,7 @@ jobs:
       working-directory: ${{ github.workspace }}/artifacts/opt
       run: |
         cp ${{github.workspace}}/conf/{config_virtio_accel.json,config_vsock.json} share/
+        cp /opt/cargo/bin/vaccelrt-agent bin/
         zip -r ${{github.workspace}}/vaccel_${{matrix.arch}}_${{matrix.build_type}}.zip bin/ include/ lib/ \
           share/config_virtio_accel.json share/config_vsock.json \
           share/fc_test share/fc_test.pub \


### PR DESCRIPTION
Include the vaccelrt-agent binary we build during the e2e test in the
release zip that we upload to s3 and Github Releases.

Signed-off-by: Babis Chalios <mail@bchalios.io>