### PR TITLE
Improvements in Firecracker root file system

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -171,7 +171,8 @@ jobs:
                 --build_dir /tmp/rootfs_build \
                 --install_prefix ${{ github.workspace }}/artifacts/opt \
                 --base_image "ubuntu:latest" \
-                --dockerfiles_path "$(pwd)/dockerfiles"
+                --dockerfiles_path "$(pwd)/dockerfiles" \
+                all
 
     - name: Create tap interface
       run: sudo ./scripts/create_tap.sh tapTestFc 172.42.0.1/24

--- a/.github/workflows/fc_rootfs.yml
+++ b/.github/workflows/fc_rootfs.yml
@@ -1,0 +1,48 @@
+name: Build Firecracker rootfs
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - dockerfiles/ubuntu/latest/Dockerfile
+  push:
+    branches:
+      - main
+    paths:
+      - dockerfiles/ubuntu/latest/Dockerfile
+  
+jobs:
+  build_image:
+    runs-on: [self-hosted, "${{ matrix.arch }}"]
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: |
+          rm -rf build
+          rm -rf output
+          ./build.sh fc_rootfs build_base_rootfs
+
+      - name: Find SHA
+        run: |
+          if [[ "${{github.event.pull_request.head.sha}}" != "" ]]
+          then
+            echo "ARTIFACT_SHA=$(echo ${{github.event.pull_request.head.sha}})" >> $GITHUB_ENV
+          else
+            echo "ARTIFACT_SHA=master" >> $GITHUB_ENV
+          fi
+
+      - name: Upload artifact to s3
+        uses: cloudkernels/minio-upload@master
+        with:
+          url: https://s3.nubificus.co.uk
+          access-key: ${{ secrets.AWS_ACCESS_KEY }}
+          secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          local-path: output/debug/share/rootfs.img
+          remote-path: nbfc-assets/github/fc_rootfs/${{ env.ARTIFACT_SHA }}/${{ matrix.arch }}/

--- a/build.sh
+++ b/build.sh
@@ -157,7 +157,8 @@ build_fc_rootfs() {
 		--install_prefix $INSTALL_PREFIX/$BUILD_TYPE \
 		--build_dir $BUILD_DIR/$BUILD_TYPE \
 		--base_image "ubuntu:latest" \
-		--dockerfiles_path $DOCKERFILES_DIR
+		--dockerfiles_path $DOCKERFILES_DIR \
+		"$@"
 	ok_or_die "Could not build rootfs"
 }
 

--- a/dockerfiles/ubuntu/latest/Dockerfile
+++ b/dockerfiles/ubuntu/latest/Dockerfile
@@ -8,7 +8,11 @@ RUN apt-get update && apt-get install -y \
       init \
       kmod \
       openssh-server \
-      udev && \
+      udev \
+      gdb \
+      valgrind \
+      rsync \
+      iproute2 && \
     apt-get clean
 
 # virtio module setup

--- a/dockerfiles/ubuntu/latest/Dockerfile
+++ b/dockerfiles/ubuntu/latest/Dockerfile
@@ -35,12 +35,8 @@ RUN echo "export VACCEL_BACKENDS=/opt/vaccel/lib/libvaccel-virtio.so" >> /root/.
 
 # Enable ssh server
 RUN systemctl enable ssh
-COPY fc_test.pub id_rsa.pub
-RUN mkdir /root/.ssh/ && \
-    cat id_rsa.pub >> /root/.ssh/authorized_keys && \
-    chmod 0700 /root/.ssh && \
-    chmod 0600 /root/.ssh/authorized_keys && \
-    chown -R root:root /root/.ssh
+RUN echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
+RUN echo "PermitEmptyPasswords yes" >> /etc/ssh/sshd_config
 
 # Disable root password
 RUN sed s/root\:x\:/root\:\:/ -i /etc/passwd

--- a/dockerfiles/ubuntu/latest/Dockerfile
+++ b/dockerfiles/ubuntu/latest/Dockerfile
@@ -15,20 +15,8 @@ RUN apt-get update && apt-get install -y \
       iproute2 && \
     apt-get clean
 
-# virtio module setup
-RUN mkdir -p /lib/modules/${KERNEL_VERSION}
-COPY share/virtio_accel.ko /lib/modules/${KERNEL_VERSION}
-RUN touch /lib/modules/${KERNEL_VERSION}/modules.order
-RUN touch /lib/modules/${KERNEL_VERSION}/modules.builtin
-RUN depmod 4.20.0
-RUN echo "virtio_accel" >> /etc/modules
-
-# Copy libvaccel inside the image
-RUN mkdir -p /opt/vaccel/bin
-COPY bin /opt/vaccel/bin
-COPY lib /opt/vaccel/lib
-COPY include /opt/vaccel/include
-COPY share /opt/vaccel/share
+# Prepare immutable vAccel properties
+RUN mkdir -p /opt/vaccel
 RUN echo "/opt/vaccel/lib" >> /etc/ld.so.conf.d/vaccel.conf
 RUN echo "/sbin/ldconfig" >> /root/.bashrc
 RUN echo "export VACCEL_BACKENDS=/opt/vaccel/lib/libvaccel-vsock.so" >> /root/.bashrc

--- a/dockerfiles/ubuntu/latest/Dockerfile
+++ b/dockerfiles/ubuntu/latest/Dockerfile
@@ -31,7 +31,8 @@ COPY include /opt/vaccel/include
 COPY share /opt/vaccel/share
 RUN echo "/opt/vaccel/lib" >> /etc/ld.so.conf.d/vaccel.conf
 RUN echo "/sbin/ldconfig" >> /root/.bashrc
-RUN echo "export VACCEL_BACKENDS=/opt/vaccel/lib/libvaccel-virtio.so" >> /root/.bashrc
+RUN echo "export VACCEL_BACKENDS=/opt/vaccel/lib/libvaccel-vsock.so" >> /root/.bashrc
+RUN echo "export VACCEL_DEBUG_LEVEL=4" >> /root/.bashrc
 
 # Enable ssh server
 RUN systemctl enable ssh

--- a/scripts/build_rootfs.sh
+++ b/scripts/build_rootfs.sh
@@ -75,9 +75,6 @@ prepare_env() {
 build() {
 	cd ${BUILD_DIR}/rootfs
 
-	# Create RSA key to rootfs
-	ssh-keygen -t rsa -f fc_test -N ""
-
 	# Create root filesystem
 	DOCKER_BUILDKIT=1 docker build \
 		--network=host \
@@ -112,7 +109,6 @@ build() {
 	sudo rmdir $mnt
 
 	cp rootfs.img ${INSTALL_PREFIX}/share/
-	cp fc_test* ${INSTALL_PREFIX}/share/
 	cp -r imagenet/networks ${INSTALL_PREFIX}/share/
 }
 

--- a/scripts/build_rootfs.sh
+++ b/scripts/build_rootfs.sh
@@ -25,29 +25,32 @@ print_help() {
 	echo "Usage: build_rootfs.sh [<args>]"
 	echo ""
 	echo "Arguments:"
+	echo "    --help|-h          Print this message and exit"
 	echo "    --build_dir        Directory to use for building (default: 'build')"
 	echo "    --install_prefix   Directory to install library (default: 'output')"
 	echo "    --base_image       Base image to use (default: ubuntu:latest)"
 	echo "    --dockerfiles_path Path to find dockerfiles for base images (default: dockerfiles)"
 	echo ""
+	echo "Available sub-commands"
+	echo ""
+	echo "    build_base_rootfs"
+	echo "        Build the base root file system (without vAccel binaries installed)"
+	echo ""
+	echo "    install_vaccel"
+	echo "        Install vAccel binaries inside root file system"
+	echo ""
+	echo "    all"
+	echo "        Build the base rootfs and then install the vAccel binaries in it"
+	echo ""
+	echo "    help"
+	echo "        Print this message"
+	echo ""
 }
 
-fetch_images() {
-	svn export https://github.com/dusty-nv/jetson-inference/trunk/data/networks networks
-}
 
-prepare_env() {
-	if [ -d ${BUILD_DIR}/rootfs ]; then
-		rm -rf ${BUILD_DIR}/rootfs/*
-	else
-		mkdir -p ${BUILD_DIR}/rootfs
-	fi
-
-	pushd ${BUILD_DIR}/rootfs > /dev/null
-
-	# Bring other components
-	cp -r ${INSTALL_PREFIX}/* .
-	ok_or_die "Could not find components"
+build_base_rootfs() {
+	mkdir -p ${BUILD_DIR}/rootfs
+	cd ${BUILD_DIR}/rootfs
 
 	# Fetch Dockerfile on which we'll base the image
 	local image=$(echo "${BASE_IMAGE}" | awk -F ":" '{print $1}')
@@ -60,20 +63,6 @@ prepare_env() {
 
 	cp ${DOCKERFILES_PATH}/${image}/${tag}/Dockerfile .
 	ok_or_die "Could not find Dockerfile for ${BASE_IMAGE}"
-
-	# Fetch imagenet
-	mkdir -p imagenet
-	pushd imagenet > /dev/null
-
-	fetch_images
-	ok_or_die "Could not fetch imagenet images"
-
-	popd > /dev/null
-	popd > /dev/null
-}
-
-build() {
-	cd ${BUILD_DIR}/rootfs
 
 	# Create root filesystem
 	DOCKER_BUILDKIT=1 docker build \
@@ -103,16 +92,56 @@ build() {
 	ok_or_die "Could not populate rootfs"
 
 	sudo umount $mnt
-	ok_or_die "Could unmount rootfs"
+	ok_or_die "Could not unmount rootfs"
 
 	sudo sync
 	sudo rmdir $mnt
 
 	cp rootfs.img ${INSTALL_PREFIX}/share/
-	cp -r imagenet/networks ${INSTALL_PREFIX}/share/
+}
+
+install_vaccel() {
+	mkdir -p ${BUILD_DIR}/rootfs
+	cd ${BUILD_DIR}/rootfs
+
+	if [ ! -f $INSTALL_PREFIX/share/rootfs.img ]; then
+		die "Base root file system is not built"
+	fi
+
+	mnt="$(mktemp -d)"
+	sudo mount $INSTALL_PREFIX/share/rootfs.img $mnt
+	ok_or_die "Could not mount rootfs"
+
+	if [[ ! -d $mnt/opt/vaccel ]] ; then
+		die "Base rootfs is not built properly"
+	fi
+
+	cp -r $INSTALL_PREFIX/{bin,lib,include,share} $mnt/opt/vaccel/
+	ok_or_die "Could not install vAccel in root file system"
+
+	# Setup VirtIO module (hardcoded kernel version)
+	mkdir -p $mnt/lib/modules/4.20.0
+	cp $INSTALL_PREFIX/share/virtio_accel.ko $mnt/lib/modules/4.20.0
+	touch $mnt/lib/modules/4.20.0/modules.order
+	touch $mnt/lib/modules/4.20.0/modules.builtin
+	echo "virtio_accel" >> $mnt/etc/modules
+	sudo chroot $mnt /sbin/depmod 4.20.0
+
+	sudo sync
+	sudo umount $mnt
+	ok_or_die "Could not unmount root file system"
+}
+
+all() {
+	build_base_rootfs
+	install_vaccel
 }
 
 main() {
+	if [ $# == 0 ]; then
+		die "Insufficient script arguments. Use \`$0 --help\'."
+	fi
+
 	while [ $# -gt 0 ]; do
 		case "$1" in
 			-h|--help)          { print_help; exit 1;         };;
@@ -120,18 +149,21 @@ main() {
 			--install_prefix)   { INSTALL_PREFIX=$2; shift;   };;
 			--base_image)       { BASE_IMAGE=$2; shift;       };;
 			--dockerfiles_path) { DOCKERFILES_PATH=$2; shift; };;
-			*)
+			*-)
 				die "Unknown argument: \"$1\". Please use \`$0 --help\`."
+				;;
+			*)
+				break;
 				;;
 		esac
 		shift
 	done
 
-	# Prepare build environment
-	prepare_env
+	# Make sure that $1 is a valid command
+	declare -f "$1" > /dev/null
+	ok_or_die "Unknown command: '$1'. Please use \`$0 --help\`."
 
-	# and build
-	build
+	$1 "$@"
 }
 
 main "$@"

--- a/scripts/build_rootfs.sh
+++ b/scripts/build_rootfs.sh
@@ -96,6 +96,12 @@ build() {
 	ok_or_die "Could not mount rootfs"
 
 	sudo rsync -aogxvPH rootfs/* $mnt
+
+	# Setup nameserver
+	# We need to do it here, because Docker does not let us change its
+	# rootfs
+	echo "nameserver 8.8.8.8" > $mnt/etc/resolv.conf
+
 	sudo chown -R root:root $mnt/root
 	ok_or_die "Could not populate rootfs"
 


### PR DESCRIPTION
We make several improvements in the Firecracker root file system image in order to ease up development / debugging:

1. We install some more packages: `gdb`, `valgrind`, `iproute2`, `rsync`
2. We set the nameserver in `/etc/resolv.conf` of the image to point to Google's nameserver
3. Allow password-less SSH access: Needing to have an RSA key around was adding unnecessary complexity

Related with: #38 