### PR TITLE
ci/cd: use pre-build Firecracker rootfs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,12 +1,21 @@
 name: Test e2e vAccel
 
 on:
+  # When a PR on main is opened
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - dockerfiles/
+
+  # When something gets pushed to main
   push:
     branches:
       - main
+    paths-ignore:
+      - dockerfiles/
+
+  # Manually
   workflow_dispatch:
 
 jobs:
@@ -67,7 +76,7 @@ jobs:
     - name: Install packages
       run: |
         sudo apt update && sudo apt install -y \
-          subversion coreutils rsync iproute2 libfdt-dev
+          subversion coreutils rsync iproute2 libfdt-dev pigz
 
     - name: Setup vars
       id: vars
@@ -162,17 +171,30 @@ jobs:
         ACTION_UID: ${{ steps.vars.outputs.uid }}
         ACTION_GID: ${{ steps.vars.outputs.gid }}
 
+    - name: Fetch Firecracker root file system
+      uses: cloudkernels/minio-download@v2
+      with:
+        url: https://s3.nubificus.co.uk
+        access-key: ${{secrets.AWS_ACCESS_KEY}}
+        secret-key: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+        local-path: /github/workspace/artifacts/opt/share/
+        remote-path: nbfc-assets/github/fc_rootfs/master/${{matrix.arch}}/rootfs.img.gz
+      env:
+        ACTION_UID: ${{steps.vars.outputs.uid}}
+        ACTION_GID: ${{steps.vars.outputs.gid}}
+
     - name: Create rootfs
       run: |
         # We need this because downloading from s3 messes up with
         # file permissions
         chmod u+x ${{ github.workspace }}/artifacts/opt/bin/*
-        ./scripts/build_rootfs.sh \
+        pigz -d ${{ github.workspace }}/artifacts/opt/share/rootfs.img.gz
+        sudo ./scripts/build_rootfs.sh \
                 --build_dir /tmp/rootfs_build \
                 --install_prefix ${{ github.workspace }}/artifacts/opt \
                 --base_image "ubuntu:latest" \
                 --dockerfiles_path "$(pwd)/dockerfiles" \
-                all
+                install_vaccel
 
     - name: Create tap interface
       run: sudo ./scripts/create_tap.sh tapTestFc 172.42.0.1/24
@@ -198,19 +220,18 @@ jobs:
       run: |
         while true
         do
-          name=$(ssh -o StrictHostKeyChecking=no -i artifacts/opt/share/fc_test root@172.42.0.2 hostname -s)
+          name=$(ssh -o StrictHostKeyChecking=no root@172.42.0.2 hostname -s)
           if [[ $name == "vaccel-guest" ]]; then exit 0; fi
         done
         exit 1
 
     - name: Test virtio-accel
-      run: ./scripts/test_virtio.sh -i ${{ github.workspace }}/artifacts/opt/share/fc_test
+      run: ./scripts/test_virtio.sh
 
     - name: Test vsock plugin
       run: |
         sudo LD_LIBRARY_PATH=${{ github.workspace }}/artifacts/opt/lib \
           ./scripts/test_vsock.sh \
-            -i ${{ github.workspace }}/artifacts/opt/share/fc_test \
             -p ${{ github.workspace }}/artifacts/opt/lib/libvaccel-noop.so \
             --agent-prefix ${{ github.workspace }}/artifacts/opt/bin
 
@@ -221,7 +242,6 @@ jobs:
         cp ${{github.workspace}}/conf/{config_virtio_accel.json,config_vsock.json} share/
         zip -r ${{github.workspace}}/vaccel_${{matrix.arch}}_${{matrix.build_type}}.zip bin/ include/ lib/ \
           share/config_virtio_accel.json share/config_vsock.json \
-          share/fc_test share/fc_test.pub \
           share/rootfs.img share/virtio_accel.ko share/vmlinux \
           share/vaccel.pc
 
@@ -241,6 +261,7 @@ jobs:
         sudo rm -rf ${{ github.workspace }}/*
         sudo rm -rf ${{ github.workspace }}/.??*
         sudo rm -f /tmp/vaccel.sock*
+        sudo rm -rf /tmp/rootfs_build
         fc_pid=$(ps aux | grep -m 1 [f]irecracker | awk '{print $2}')
         while true
         do

--- a/.github/workflows/fc_rootfs.yml
+++ b/.github/workflows/fc_rootfs.yml
@@ -24,11 +24,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install packages
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+            pigz
+
       - name: Build image
         run: |
           rm -rf build
           rm -rf output
           ./build.sh fc_rootfs build_base_rootfs
+          pigz -9 output/debug/share/rootfs.img
 
       - name: Find SHA
         run: |
@@ -45,5 +51,5 @@ jobs:
           url: https://s3.nubificus.co.uk
           access-key: ${{ secrets.AWS_ACCESS_KEY }}
           secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          local-path: output/debug/share/rootfs.img
+          local-path: output/debug/share/rootfs.img.gz
           remote-path: nbfc-assets/github/fc_rootfs/${{ env.ARTIFACT_SHA }}/${{ matrix.arch }}/

--- a/.github/workflows/fc_rootfs.yml
+++ b/.github/workflows/fc_rootfs.yml
@@ -11,6 +11,7 @@ on:
       - main
     paths:
       - dockerfiles/ubuntu/latest/Dockerfile
+  workflow_dispatch:
   
 jobs:
   build_image:

--- a/scripts/test_virtio.sh
+++ b/scripts/test_virtio.sh
@@ -12,9 +12,6 @@ SSH_TIMEOUT=300
 # Firecracker IP
 FC_IP="172.42.0.2"
 
-# Path to ssh private key
-SSH_KEY=$(pwd)/opt/share/fc_test
-
 # script name for logging
 LOG_NAME="$(basename $0)"
 
@@ -28,19 +25,18 @@ print_help() {
 	echo "    -v|--vaccel     Directory of vAccel installation (default: '/opt/vaccel')"
 	echo "    -t|--timeout    Timeout in seconds to wait response from Firecracker (default: 300)"
 	echo "    -a|--ip-address Address of Firecracker VM"
-	echo "    -i|--ssh-key    RSA key to use for SSHing inside the VM"
 	echo ""
 }
 
 _run_ssh_test() {
-	ssh -o StrictHostKeyChecking=no -i $SSH_KEY root@$FC_IP $1
+	ssh -o StrictHostKeyChecking=no root@$FC_IP $1
 }
 
 test_image_classification() {
 	in_fc_cmd="LD_LIBRARY_PATH=$VACCEL_PATH/lib"
 	in_fc_cmd="$in_fc_cmd VACCEL_BACKENDS=$VACCEL_PATH/lib/libvaccel-virtio.so"
 	in_fc_cmd="$in_fc_cmd VACCEL_DEBUG_LEVEL=4"
-	in_fc_cmd="$in_fc_cmd $VACCEL_PATH/bin/classify $VACCEL_PATH/share/images/example.jpg 1"
+	in_fc_cmd="$in_fc_cmd $VACCEL_PATH/bin/classify $VACCEL_PATH/share/images/dog_1.jpg 1"
 
 	_run_ssh_test "$in_fc_cmd"
 }
@@ -56,7 +52,6 @@ main() {
 			-v|--vaccel)      { VACCEL_PATH=$2; shift; };;
 			-t|--timeout)     { SSH_TIMEOUT=$2; shift; };;
 			-a|--ip-address)  { FC_IP=$2; shift;       };;
-			-i|--ssh-key)     { SSH_KEY=$2; shift;     };;
 			*)
 				die "Unknown argument: \"$1\". Please use \`$0 --help\`."
 				;;

--- a/scripts/test_vsock.sh
+++ b/scripts/test_vsock.sh
@@ -12,9 +12,6 @@ SSH_TIMEOUT=300
 # Firecracker IP
 FC_IP="172.42.0.2"
 
-# Path to ssh private key
-SSH_KEY=$(pwd)/opt/share/fc_test
-
 # vsock socket to use inside the VM
 VACCEL_VSOCK="vsock://2:2048"
 
@@ -43,7 +40,6 @@ print_help() {
 	echo "    -v|--vaccel     Directory of vAccel installation (default: '/opt/vaccel')"
 	echo "    -t|--timeout    Timeout in seconds to wait response from Firecracker (default: 300)"
 	echo "    -a|--ip-address Address of Firecracker VM"
-	echo "    -i|--ssh-key    RSA key to use for SSHing inside the VM"
 	echo "    -p|--plugin     Plugin to use for agent"
 	echo "    --agent-prefix  Location of the agent binary"
 	echo "    --vsock         Vsock socket to use inside the VM"
@@ -65,7 +61,7 @@ kill_agent() {
 }
 
 _run_ssh_test() {
-	ssh -o StrictHostKeyChecking=no -i $SSH_KEY root@$FC_IP $1
+	ssh -o StrictHostKeyChecking=no root@$FC_IP $1
 }
 
 test_image_classification() {
@@ -74,7 +70,7 @@ test_image_classification() {
 	in_fc_cmd="$in_fc_cmd VACCEL_BACKENDS=$VACCEL_PATH/lib/libvaccel-vsock.so"
 	in_fc_cmd="$in_fc_cmd VACCEL_VSOCK=$VACCEL_VSOCK"
 	in_fc_cmd="$in_fc_cmd VACCEL_DEBUG_LEVEL=4"
-	in_fc_cmd="$in_fc_cmd $VACCEL_PATH/bin/classify $VACCEL_PATH/share/images/example.jpg 1"
+	in_fc_cmd="$in_fc_cmd $VACCEL_PATH/bin/classify $VACCEL_PATH/share/images/dog_1.jpg 1"
 
 	_run_ssh_test "$in_fc_cmd"
 }
@@ -140,7 +136,6 @@ main() {
 			-v|--vaccel)      { VACCEL_PATH=$2; shift;  };;
 			-t|--timeout)     { SSH_TIMEOUT=$2; shift;  };;
 			-a|--ip-address)  { FC_IP=$2; shift;        };;
-			-i|--ssh-key)     { SSH_KEY=$2; shift;      };;
 			-p|--plugin)      { PLUGIN=$2; shift;       };;
 			--agent-prefix)   { AGENT_PREFIX=$2; shift; };;
 			--vsock)          { VACCEL_VSOCK=$2; shift; };;


### PR DESCRIPTION
Instead of building the Firecracker rootfs, just use the one we have
pre-built from latest master and install inside the vAccel binaries.

Related with #38 

Signed-off-by: Babis Chalios <mail@bchalios.io>