### PR TITLE
Update rust-vaccel pointer

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,7 @@ on:
       - bindings
       - conf
       - firecracker
-      - plugins
+      - "plugins/**"
       - scripts/build_rootfs.sh
       - scripts/create_tap.sh
       - scripts/test_virtio.sh
@@ -30,7 +30,7 @@ on:
       - bindings
       - conf
       - firecracker
-      - plugins
+      - "plugins/**"
       - scripts/build_rootfs.sh
       - scripts/create_tap.sh
       - scripts/test_virtio.sh


### PR DESCRIPTION
In rust bindings we updated the vaccelrt pointer to point to the
licensed version of vaccelrt.

Signed-off-by: Babis Chalios <mail@bchalios.io>