### PR TITLE
We don't need to run build container with -ti

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,7 +52,7 @@ prepare_build_env() {
 }
 
 runctr() {
-	docker run --rm -ti \
+	docker run --rm \
 	       -v $SOURCEDIR:$SOURCEDIR \
 	       -v $BUILD_DIR:$BUILD_DIR \
 	       -v $INSTALL_PREFIX:$INSTALL_PREFIX \


### PR DESCRIPTION
This breaks stuff when we try to build from something that is not a TTY,
e.g. a Github Actions runner and we really don't need it anyway.

Signed-off-by: Babis Chalios <mail@bchalios.io>